### PR TITLE
Typescript, close() and github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ ps.events.on("error", err => {
   console.log(err)
 })
 ```
+## Shutdown
+
+This fork provides a new `async close():Promise<void>` method that can be called to stop the listeners and release the `pg` connection for a clean shutdown.
 
 ## Development
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+import { PubSub } from "graphql-subscriptions";
+
+export class PostgresPubSub extends PubSub {
+	constructor(options?: {});
+	pgListen: any;
+	triggers: any;
+	events: any;
+	commonMessageHandler: any;
+	connected: boolean;
+	connect(): Promise<void>;
+	close(): Promise<void>;
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/GraphQLCollege/graphql-postgres-subscriptions.git"
+    "url": "https://github.com/originlabs/graphql-postgres-subscriptions"
   },
   "peerDependencies": {
     "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -74,6 +74,11 @@ class PostgresPubSub extends PubSub {
     delete this.subscriptions[subId];
     this.pgListen.unlisten(triggerName);
   }
+  async close() {
+    await this.pgListen.unlistenAll();
+    await this.pgListen.close();
+    this.connected = false;
+  }
 
   asyncIterator(triggers) {
     return eventEmitterAsyncIterator(


### PR DESCRIPTION
Small PR, contains:

* Basic `index.d.ts` (not strongly typed)
* Added `close` method to release `pgListen` connection handle
* Changed githib reference url in `package.json` to reference `originlabs` instead of `GraphQLCollege`
* Updated `readme` to document `close()`