### PR TITLE
Do not return promise from event listener

### DIFF
--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -35,11 +35,12 @@ class PostgresPubSub extends PubSub {
     // but then it will retry and emit a `connected` event if it later connects
     // see https://github.com/andywer/pg-listen/issues/32
     // so we put logic on the `connected` event
-    this.pgListen.events.on('connected', async () => {
-      await Promise.all(this.triggers.map((eventName) => {
+    this.pgListen.events.on('connected', () => {
+      Promise.all(this.triggers.map((eventName) => {
         return this.pgListen.listenTo(eventName);
-      }));
-      this.connected = true;
+      })).then(() => {
+        this.connected = true;
+      });
     });
     try {
       await this.pgListen.connect();

--- a/postgres-pubsub.test.js
+++ b/postgres-pubsub.test.js
@@ -13,7 +13,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "test");
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("PostgresPubSub can subscribe and is called when events happen", async function(done) {
@@ -25,7 +25,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "test");
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("PostgresPubSub can subscribe when instantiated with connection options but without a client", async function(done) {
@@ -39,7 +39,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "test");
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("PostgresPubSub can unsubscribe", async function(done) {
@@ -54,7 +54,7 @@ describe("PostgresPubSub", () => {
       expect(succeed).resolves.toBe(true); // True because publish success is not
       // indicated by trigger having subscriptions
       done(); // works because pubsub is synchronous
-    });
+    }).catch(done);
   });
 
   test("Should emit error when payload exceeds Postgres 8000 character limit", async (done) => {
@@ -72,7 +72,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "a".repeat(9000));
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("AsyncIterator should expose valid asyncIterator for a specific event", () => {
@@ -94,7 +94,7 @@ describe("PostgresPubSub", () => {
       expect(result.value).not.toBeUndefined();
       expect(result.done).not.toBeUndefined();
       done();
-    });
+    }).catch(done);
 
     ps.publish(eventName, { test: true });
   });
@@ -123,7 +123,7 @@ describe("PostgresPubSub", () => {
       spy();
       expect(spy).toHaveBeenCalled();
       done();
-    });
+    }).catch(done);
     ps.publish(eventName, { test: true });
   });
 
@@ -139,7 +139,7 @@ describe("PostgresPubSub", () => {
       expect(result.value).toEqual({ transformed: { test: true } });
       expect(result.done).toBe(false);
       done();
-    });
+    }).catch(done);
 
     ps.publish(eventName, { test: true });
   });
@@ -154,7 +154,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("transform", { test: true });
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   // This test does not clean up after it ends. It breaks the test that follows after it.
@@ -172,7 +172,7 @@ describe("PostgresPubSub", () => {
       expect(result).not.toBeUndefined();
       expect(result.value).not.toBeUndefined();
       expect(result.done).toBe(false);
-    });
+    }).catch(done);
 
     ps.publish(eventName, { test: true });
 
@@ -183,7 +183,7 @@ describe("PostgresPubSub", () => {
       expect(result.value).toBeUndefined();
       expect(result.done).toBe(true);
       done();
-    });
+    }).catch(done);
 
     await delay(0);
 


### PR DESCRIPTION
Fixes #3 

- Don't return promise from event listener
- Ensure all promises in tests have any rejection values fed to `done`, to signal to Jest that the test failed

Intent here is to fix the linked issue without changing the semantics of `this.connected`.

Haven't been able to verify that existing tests pass; see my comment [here](https://github.com/originlabs/graphql-postgres-subscriptions/issues/2#issuecomment-840929356) for details. We'll see if CI passes on this PR branch.