### PR TITLE
Ensure `connect` only fulfills once all requested triggers are ready

### DIFF
--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -35,11 +35,12 @@ class PostgresPubSub extends PubSub {
     // but then it will retry and emit a `connected` event if it later connects
     // see https://github.com/andywer/pg-listen/issues/32
     // so we put logic on the `connected` event
-    this.pgListen.events.on('connected', async () => {
-      await Promise.all(this.triggers.map((eventName) => {
+    this.pgListen.events.on('connected', () => {
+      Promise.all(this.triggers.map((eventName) => {
         return this.pgListen.listenTo(eventName);
-      }));
-      this.connected = true;
+      })).then(() => {
+        this.connected = true;
+      });
     });
     try {
       await this.pgListen.connect();

--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -65,7 +65,7 @@ class PostgresPubSub extends PubSub {
     try {
       await this.pgListen.connect();
     } catch (e) {
-      if (!e.message.includes('ECONNREFUSED')) reject(e);
+      if (!e.message.includes('ECONNREFUSED')) throw e;
     }
 
     await eventPromises;

--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -31,12 +31,12 @@ class PostgresPubSub extends PubSub {
 
   /**
    * @returns
-   * Rejects with the sooner of
-   *   1. pg-listen's initial `connect` failing for an exotic (i.e., non-ECONNREFUSED)
+   * Rejects when any of the following occur:
+   *   1. pg-listen's initial `connect` fails for an exotic (i.e., non-ECONNREFUSED)
    *      reason.
-   *   2. pg-listen emitting 'error', likely indicating initial connection failed
+   *   2. pg-listen emits 'error', likely indicating initial connection failed
    *      even after repeated attempts.
-   *   3. Connection to the database was initially successful, but at least one
+   *   3. Connection to the database was successful, but at least one
    *      `LISTEN` query failed.
    *
    * Fulfills otherwise, indicating all of the requested triggers are now being

--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -29,6 +29,19 @@ class PostgresPubSub extends PubSub {
     this.connected = false;
   }
 
+  /**
+   * @returns
+   * Rejects with the sooner of
+   *   1. pg-listen's initial `connect` failing for an exotic (i.e., non-ECONNREFUSED)
+   *      reason.
+   *   2. pg-listen emitting 'error', likely indicating initial connection failed
+   *      even after repeated attempts.
+   *   3. Connection to the database was initially successful, but at least one
+   *      `LISTEN` query failed.
+   *
+   * Fulfills otherwise, indicating all of the requested triggers are now being
+   * listened to.
+   */
   connect() {
     return new Promise(async (resolve, reject) => {
       this.pgListen.events.once('connected', () => {

--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -44,6 +44,10 @@ class PostgresPubSub extends PubSub {
    */
   connect() {
     return new Promise(async (resolve, reject) => {
+      // confusingly, `pgListen.connect()` will reject if the first connection attempt fails
+      // but then it will retry and emit a `connected` event if it later connects
+      // see https://github.com/andywer/pg-listen/issues/32
+      // so we put logic on the `connected` event
       this.pgListen.events.once('connected', () => {
         Promise.all(this.triggers.map((eventName) => {
           return this.pgListen.listenTo(eventName);

--- a/postgres-pubsub.test.js
+++ b/postgres-pubsub.test.js
@@ -13,7 +13,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "test");
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("PostgresPubSub can subscribe and is called when events happen", async function(done) {
@@ -25,7 +25,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "test");
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("PostgresPubSub can subscribe when instantiated with connection options but without a client", async function(done) {
@@ -39,7 +39,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "test");
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("PostgresPubSub can unsubscribe", async function(done) {
@@ -54,7 +54,7 @@ describe("PostgresPubSub", () => {
       expect(succeed).resolves.toBe(true); // True because publish success is not
       // indicated by trigger having subscriptions
       done(); // works because pubsub is synchronous
-    });
+    }).catch(done);
   });
 
   test("Should emit error when payload exceeds Postgres 8000 character limit", async (done) => {
@@ -72,7 +72,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("a", "a".repeat(9000));
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   test("AsyncIterator should expose valid asyncIterator for a specific event", () => {
@@ -94,7 +94,7 @@ describe("PostgresPubSub", () => {
       expect(result.value).not.toBeUndefined();
       expect(result.done).not.toBeUndefined();
       done();
-    });
+    }).catch(done);
 
     ps.publish(eventName, { test: true });
   });
@@ -123,7 +123,7 @@ describe("PostgresPubSub", () => {
       spy();
       expect(spy).toHaveBeenCalled();
       done();
-    });
+    }).catch(done);
     ps.publish(eventName, { test: true });
   });
 
@@ -139,7 +139,7 @@ describe("PostgresPubSub", () => {
       expect(result.value).toEqual({ transformed: { test: true } });
       expect(result.done).toBe(false);
       done();
-    });
+    }).catch(done);
 
     ps.publish(eventName, { test: true });
   });
@@ -154,7 +154,7 @@ describe("PostgresPubSub", () => {
     }).then(() => {
       const succeed = ps.publish("transform", { test: true });
       expect(succeed).resolves.toBe(true);
-    });
+    }).catch(done);
   });
 
   // This test does not clean up after it ends. It breaks the test that follows after it.
@@ -172,7 +172,7 @@ describe("PostgresPubSub", () => {
       expect(result).not.toBeUndefined();
       expect(result.value).not.toBeUndefined();
       expect(result.done).toBe(false);
-    });
+    }).catch(done);
 
     ps.publish(eventName, { test: true });
 
@@ -183,7 +183,7 @@ describe("PostgresPubSub", () => {
       expect(result.value).toBeUndefined();
       expect(result.done).toBe(true);
       done();
-    });
+    }).catch(done);
 
     await delay(0);
 


### PR DESCRIPTION
Fixes https://github.com/originlabs/graphql-postgres-subscriptions/issues/2

**Depends on https://github.com/originlabs/graphql-postgres-subscriptions/pull/4.**

Great news: All tests pass!

```
 PASS  ./postgres-pubsub.test.js
  PostgresPubSub
    ✓ PostgresPubSub can subscribe when instantiated without a client (10 ms)
    ✓ PostgresPubSub can subscribe and is called when events happen (7 ms)
    ✓ PostgresPubSub can subscribe when instantiated with connection options but without a client (5 ms)
    ✓ PostgresPubSub can unsubscribe (5 ms)
    ✓ Should emit error when payload exceeds Postgres 8000 character limit (7 ms)
    ✓ AsyncIterator should expose valid asyncIterator for a specific event
    ✓ AsyncIterator should trigger event on asyncIterator when published (7 ms)
    ✓ AsyncIterator should not trigger event on asyncIterator when publishing other event (4 ms)
    ✓ AsyncIterator should register to multiple events (4 ms)
    ✓ AsyncIterator transforms messages using commonMessageHandler (7 ms)
    ✓ PostgresPubSub transforms messages using commonMessageHandler (4 ms)
    ✓ AsyncIterator should not trigger event on asyncIterator already returned (8 ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        0.48 s, estimated 1 s
Ran all test suites.
```

The `@returns` docstring is [TSDoc](https://tsdoc.org) syntax, which at least VS Code understands:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/5624115/118213249-65847780-b422-11eb-9744-23c021712042.png">
