### PR TITLE
feat: Expose pg-listen errors during `publish`

### DIFF
--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -75,15 +75,11 @@ class PostgresPubSub extends PubSub {
 
   async publish(triggerName, payload) {
     if (!this.connected) {
-      console.log(`attempted to publish a ${triggerName} event via pubsub, but client is not yet connected`)
-      return false;
+      const message = `attempted to publish a ${triggerName} event via pubsub, but client is not yet connected`;
+      return Promise.reject(new Error(message));
     }
 
-    try {
-      await this.pgListen.notify(triggerName, payload);
-    } catch (e) {
-      this.pgListen.events.emit('error', e)
-    }
+    await this.pgListen.notify(triggerName, payload);
     return true;
   }
   async subscribe(triggerName, onMessage) {

--- a/postgres-pubsub.test.js
+++ b/postgres-pubsub.test.js
@@ -57,22 +57,14 @@ describe("PostgresPubSub", () => {
     }).catch(done);
   });
 
-  test("Should emit error when payload exceeds Postgres 8000 character limit", async (done) => {
+  test("Should emit error when payload exceeds Postgres 8000 character limit", async () => {
     const ps = new PostgresPubSub();
     await ps.connect();
 
-    ps.events.on("error", err => {
-      expect(err.toString()).toContain('payload')
-      done();
-    })
-
-    ps.subscribe("a", () => {
-      expect(false).toBe(true); // Should not reach this point
-      done();
-    }).then(() => {
-      const succeed = ps.publish("a", "a".repeat(9000));
-      expect(succeed).resolves.toBe(true);
-    }).catch(done);
+    await ps.subscribe("a", () => {});
+    await expect(
+      ps.publish("a", "a".repeat(9000))
+    ).rejects.toThrow('payload string too long');
   });
 
   test("AsyncIterator should expose valid asyncIterator for a specific event", () => {


### PR DESCRIPTION
Fixes https://github.com/originlabs/graphql-postgres-subscriptions/issues/6

This is probably a semver-major change for two reasons:

1. Where before `publish` always returned a promise that fulfills with `true`, here it may reject, reflecting the underlying failure of the `NOTIFY` operation.
2. Where before `publish` would emit an `'error'` event when publication failed, now it will never do so.