### PR TITLE
build: Fix CI, test on Node.js 14, 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ language: node_js
 node_js:
   - 16
   - 14
-  - 12
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
+arch: arm64-graviton2
+virt: lxd
+os: linux
+dist: focal
+# Note: this is required until arm64-graviton2 is "promoted"
+# source: https://blog.travis-ci.com/2020-09-11-arm-on-aws#how-to-get-started
+group: edge
+
 language: node_js
 node_js:
-- "8"
-- "6"
-sudo: required
+  - 16
+  - 14
+  - 12
+
 services:
   - docker
-before_install:
-  - docker-compose build
-script:
-  - docker-compose run test
+  - postgres
+
+env:
+  global:
+    - PGHOST=localhost
+    - PGUSER=postgres
+    - PGDATABASE=postgres
+    - PGDATABASE_URL=postgres://postgres:@localhost:5432/postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:12.21.0
+FROM mhart/alpine-node:16
 WORKDIR /test
 ADD . /test/
 RUN yarn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: "3.8"
+version: "3.7"
 services:
   db:
-    image: postgres:13.2-alpine
+    image: postgres:12.2-alpine
     ports:
       - 5432
     environment:


### PR DESCRIPTION
- Update the Travis CI config to run the latest and most recommended software
- Test against currently non-maintenance-mode Node LTS releases: 14 and 16 ([source](https://nodejs.org/en/about/releases/))
- Update Docker resources to more closely match the CI environment

Confirmed that this passes: https://travis-ci.com/github/uptrust/graphql-postgres-subscriptions/builds/227907299

Thought it'd be valuable to have an easy way to test against multiple Node.js versions, and I didn't know how to pull that off while preserving the docker-compose based test workflow. As a result in CI the tests run natively, not in Docker.